### PR TITLE
Add minimal OpenAI agent swarm demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# ecosystemsimulator
+# Ecosystem Simulator
+
+This repository contains a minimal prototype of a generative simulation swarm using the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/).
+
+The demo spins up multiple lightweight agents (founders, VCs and mentors) that interact over a few simulation ticks. Each agent produces a short action which is printed to the console.
+
+## Requirements
+
+* Python 3.12+
+* `openai` and `openai-agents` packages
+* An OpenAI API key set in the environment variable `OPENAI_API_KEY`
+
+Install the dependencies with:
+
+```bash
+pip install openai openai-agents
+```
+
+## Running the demo
+
+Run `python src/simulation.py` to start the simulation. By default it spawns 10 agents and runs three ticks. You can configure the number of agents or steps via command line arguments:
+
+```bash
+python src/simulation.py 20 5
+```
+
+## Notes
+
+This is a simple starting point for experimentation during a hackathon. You can extend the simulation with vector-store based memory, additional agent roles and more sophisticated world state updates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0
+openai-agents>=0.0.17

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,0 +1,67 @@
+import os
+import random
+from typing import List
+
+from agents import Agent, Runner
+
+DEFAULT_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+class World:
+    def __init__(self, agents: List[Agent]):
+        self.agents = agents
+        self.history = []
+
+    def step(self):
+        events = []
+        for agent in self.agents:
+            context = "\n".join(self.history[-5:])
+            result = Runner.run_sync(agent, context)
+            action = result.final_output
+            msg = f"{agent.name}: {action}"
+            events.append(msg)
+            self.history.append(msg)
+        return events
+
+
+def create_agents(num_agents: int) -> List[Agent]:
+    agents = []
+    for i in range(num_agents):
+        role = random.choice(["Founder", "VC", "Mentor"])
+        instructions = f"You are {role} #{i}. Make short decisions in a startup ecosystem."\
+            " Respond with a brief action for this simulation tick."
+        agent = Agent(name=f"{role}_{i}", instructions=instructions, model=DEFAULT_MODEL)
+        agents.append(agent)
+    return agents
+
+
+def main(num_agents: int = 10, steps: int = 3):
+    """Run the simulation with the given number of agents and steps."""
+    agents = create_agents(num_agents)
+    world = World(agents)
+    for step in range(steps):
+        print(f"--- Tick {step + 1} ---")
+        try:
+            events = world.step()
+        except Exception as exc:
+            print(f"Error running agents: {exc}")
+            print("Ensure the OPENAI_API_KEY environment variable is set.")
+            return
+
+        for e in events:
+            print(e)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) >= 2:
+        num_agents = int(sys.argv[1])
+    else:
+        num_agents = 10
+
+    if len(sys.argv) >= 3:
+        steps = int(sys.argv[2])
+    else:
+        steps = 3
+
+    main(num_agents, steps)


### PR DESCRIPTION
## Summary
- create a Python-based simulation prototype using the OpenAI Agents SDK
- update README with setup and usage instructions
- add requirements.txt for dependencies

## Testing
- `python -m py_compile src/simulation.py`
- `python src/simulation.py 1 1` *(fails without API key)*

------
https://chatgpt.com/codex/tasks/task_e_6844635d4c088331a3aba948ba9f1f68