### PR TITLE
Add minimal FastAPI web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# ecosystemsimulator
+# Ecosystem Simulator
+
+This repository contains a minimal prototype of a generative simulation swarm using the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/).
+
+The demo spins up multiple lightweight agents (founders, VCs and mentors) that interact over a few simulation ticks. Each agent produces a short action which is printed to the console.
+
+## Requirements
+
+* Python 3.12+
+* `openai`, `openai-agents`, `fastapi`, and `uvicorn` packages
+* An OpenAI API key set in the environment variable `OPENAI_API_KEY`
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the demo
+
+Run `python src/simulation.py` to start the simulation. By default it spawns 10 agents and runs three ticks. You can configure the number of agents or steps via command line arguments:
+
+```bash
+python src/simulation.py 20 5
+```
+
+### Running as a web service
+
+You can also launch a small FastAPI server that exposes the simulation via HTTP:
+
+```bash
+uvicorn main:app --reload
+```
+
+Then POST to `/simulate` with JSON like `{"num_agents": 5, "steps": 2}` to run a simulation and receive the events.
+
+## Notes
+
+This is a simple starting point for experimentation during a hackathon. You can extend the simulation with vector-store based memory, additional agent roles and more sophisticated world state updates.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+from src.simulation import create_agents, World
+
+app = FastAPI(title="Ecosystem Simulator")
+
+class SimulationRequest(BaseModel):
+    num_agents: int = 10
+    steps: int = 3
+
+class SimulationResponse(BaseModel):
+    events: List[List[str]]
+
+
+def run_simulation(num_agents: int, steps: int) -> List[List[str]]:
+    agents = create_agents(num_agents)
+    world = World(agents)
+    all_events: List[List[str]] = []
+    for _ in range(steps):
+        events = world.step()
+        all_events.append(events)
+    return all_events
+
+@app.get("/")
+async def root():
+    return {"message": "Ecosystem Simulator is running"}
+
+@app.post("/simulate", response_model=SimulationResponse)
+async def simulate(req: SimulationRequest):
+    events = run_simulation(req.num_agents, req.steps)
+    return {"events": events}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0
+openai-agents>=0.0.17
+fastapi>=0.110
+uvicorn>=0.29

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,0 +1,67 @@
+import os
+import random
+from typing import List
+
+from agents import Agent, Runner
+
+DEFAULT_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+class World:
+    def __init__(self, agents: List[Agent]):
+        self.agents = agents
+        self.history = []
+
+    def step(self):
+        events = []
+        for agent in self.agents:
+            context = "\n".join(self.history[-5:])
+            result = Runner.run_sync(agent, context)
+            action = result.final_output
+            msg = f"{agent.name}: {action}"
+            events.append(msg)
+            self.history.append(msg)
+        return events
+
+
+def create_agents(num_agents: int) -> List[Agent]:
+    agents = []
+    for i in range(num_agents):
+        role = random.choice(["Founder", "VC", "Mentor"])
+        instructions = f"You are {role} #{i}. Make short decisions in a startup ecosystem."\
+            " Respond with a brief action for this simulation tick."
+        agent = Agent(name=f"{role}_{i}", instructions=instructions, model=DEFAULT_MODEL)
+        agents.append(agent)
+    return agents
+
+
+def main(num_agents: int = 10, steps: int = 3):
+    """Run the simulation with the given number of agents and steps."""
+    agents = create_agents(num_agents)
+    world = World(agents)
+    for step in range(steps):
+        print(f"--- Tick {step + 1} ---")
+        try:
+            events = world.step()
+        except Exception as exc:
+            print(f"Error running agents: {exc}")
+            print("Ensure the OPENAI_API_KEY environment variable is set.")
+            return
+
+        for e in events:
+            print(e)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) >= 2:
+        num_agents = int(sys.argv[1])
+    else:
+        num_agents = 10
+
+    if len(sys.argv) >= 3:
+        steps = int(sys.argv[2])
+    else:
+        steps = 3
+
+    main(num_agents, steps)


### PR DESCRIPTION
## Summary
- add main.py with a FastAPI server exposing the simulation
- update README with installation and server instructions
- include FastAPI and Uvicorn in dependencies

## Testing
- `python -m py_compile src/simulation.py main.py`
- `python src/simulation.py 1 1` *(fails without API key)*
- `uvicorn main:app --port 8000 --workers 1 --reload` *(manual startup works)*

------
https://chatgpt.com/codex/tasks/task_e_6844635d4c088331a3aba948ba9f1f68